### PR TITLE
KOHA-1065 Email sent even though patron has not chosen email

### DIFF
--- a/misc/cronjobs/overdue_notices.pl
+++ b/misc/cronjobs/overdue_notices.pl
@@ -33,6 +33,7 @@ use Pod::Usage;
 use Text::CSV_XS;
 use DateTime;
 use DateTime::Duration;
+use List::MoreUtils qw( uniq );
 
 use C4::Context;
 use C4::Letters;
@@ -678,11 +679,15 @@ END_SQL
                     if($patronpref && $patronpref->{'transports'}) {
                         @message_transport_types = keys($patronpref->{'transports'});
                     }
-                }
-                @message_transport_types = @{ GetOverdueMessageTransportTypes( $branchcode, $overdue_rules->{categorycode}, $i) } unless @message_transport_types;
-                @message_transport_types = @{ GetOverdueMessageTransportTypes( q{}, $overdue_rules->{categorycode}, $i) }
-                    unless @message_transport_types;
+                    if(!@message_transport_types || (grep {/^print$/} @message_transport_types)) {
+                        @message_transport_types = uniq( 'print', @message_transport_types ) 
+                    }
 
+                } else {
+                    @message_transport_types = @{ GetOverdueMessageTransportTypes( $branchcode, $overdue_rules->{categorycode}, $i) };
+                    @message_transport_types = @{ GetOverdueMessageTransportTypes( q{}, $overdue_rules->{categorycode}, $i) }
+                    unless @message_transport_types;
+                }
 
                 my $print_sent = 0; # A print notice is not yet sent for this patron
                 for my $mtt ( @message_transport_types ) {


### PR DESCRIPTION
This is due to falling back on old behaviour (which sets email based on patron category).

Solution:
Do not fall back on old behaviour. Instead set transport type to print if patron has not chosen email and/or sms for overdues.