### PR TITLE
Correction of a typo.

### DIFF
--- a/acqui/edifactmsgs.pl
+++ b/acqui/edifactmsgs.pl
@@ -32,7 +32,7 @@ my ( $template, $loggedinuser, $cookie, $userflags ) = get_template_and_user(
         query           => $q,
         type            => 'intranet',
         authnotrequired => 0,
-        flagsrequired   => { acquisition => 'manage_edi' },
+        flagsrequired   => { acquisition => 'edi_manage' },
         debug           => 1,
     }
 );

--- a/acqui/edimsg.pl
+++ b/acqui/edimsg.pl
@@ -32,7 +32,7 @@ my ( $template, $loggedinuser, $cookie, $userflags ) = get_template_and_user(
         query           => $q,
         type            => 'intranet',
         authnotrequired => 0,
-        flagsrequired   => { acquisition => 'manage_edi' },
+        flagsrequired   => { acquisition => 'edi_manage' },
         debug           => 1,
     }
 );


### PR DESCRIPTION
- The role name is edi_manage but was spelled manage_edi when
  checking the access rights for cgi-bin/koha/acqui/edifactmsgs.pl.
  This is now corrected in file acqui/edifactmsgs.pl
- Also corrected the same error in file acqui/edimsg.pl
- Found no other occurrences of *manage_edi* in the source code.