### PR TITLE
Bug 20589: Add field boosting and use query_string fields parameter

### DIFF
--- a/Koha/Schema/Result/SearchField.pm
+++ b/Koha/Schema/Result/SearchField.pm
@@ -68,6 +68,12 @@ __PACKAGE__->add_columns(
     extra => { list => ["", "string", "date", "number", "boolean", "sum"] },
     is_nullable => 0,
   },
+  "boost",
+  { data_type => "decimal", size => [ 5, 2 ], is_nullable => 1 },
+  "staff_client",
+  { data_type => "tinyint", size => 1, is_nullable => 0, default => 1 },
+  "opac",
+  { data_type => "tinyint", size => 1, is_nullable => 0, default => 1 },
 );
 
 =head1 PRIMARY KEY

--- a/Koha/Schema/Result/SearchMarcToField.pm
+++ b/Koha/Schema/Result/SearchMarcToField.pm
@@ -71,6 +71,8 @@ __PACKAGE__->add_columns(
   { data_type => "tinyint", default_value => 0, is_nullable => 1 },
   "sort",
   { data_type => "tinyint", is_nullable => 1 },
+  "search",
+  { data_type => "tinyint", size => 1, is_nullable => 0, default => 1 },
 );
 
 =head1 PRIMARY KEY

--- a/installer/data/mysql/atomicupdate/bug_20589_add_columns.perl
+++ b/installer/data/mysql/atomicupdate/bug_20589_add_columns.perl
@@ -1,0 +1,17 @@
+$DBversion = 'XXX';
+if (CheckVersion($DBversion)) {
+  if (!column_exists('search_marc_to_field', 'search')) {
+    $dbh->do("ALTER TABLE `search_marc_to_field` ADD COLUMN `search` tinyint(1) NOT NULL DEFAULT 1");
+  }
+  if (!column_exists('search_field', 'boost')) {
+    $dbh->do("ALTER TABLE `search_field` ADD COLUMN `boost` decimal(5,2) DEFAULT NULL");
+  }
+  if (!column_exists('search_field', 'staff_client')) {
+    $dbh->do("ALTER TABLE `search_field` ADD COLUMN `staff_client` tinyint(1) NOT NULL DEFAULT 1");
+  }
+  if (!column_exists('search_field', 'opac')) {
+    $dbh->do("ALTER TABLE `search_field` ADD COLUMN `opac` tinyint(1) NOT NULL DEFAULT 1");
+  }
+  SetVersion($DBversion)
+}
+print "Upgrade to $DBversion done (Bug 20589 - Add field boosting and use elastic query fields parameter instead of depricated _all)\n";

--- a/koha-tmpl/intranet-tmpl/prog/en/modules/admin/searchengine/elasticsearch/mappings.tt
+++ b/koha-tmpl/intranet-tmpl/prog/en/modules/admin/searchengine/elasticsearch/mappings.tt
@@ -126,6 +126,14 @@ a.add, a.delete {
                     <th>Name</th>
                     <th>Label</th>
                     <th>Type</th>
+                    <th colspan="2">Searchable</th>
+                    <th>Boost</th>
+                  </tr>
+                  <tr>
+                    <th colspan=3>&nbsp;</th>
+                    <th>Staff client</th>
+                    <th>OPAC</th>
+                    <th>&nbsp;</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -134,7 +142,9 @@ a.add, a.delete {
                       <td>
                         <input type="text" name="search_field_name" value="[% search_field.name %]" />
                       </td>
-                      <td><input type="text" name="search_field_label" value="[% search_field.label %]" />
+                      <td>
+                        <input type="text" name="search_field_label" value="[% search_field.label %]" />
+                      </td>
                       <td>
                         <select name="search_field_type">
                           <option value=""></option>
@@ -165,6 +175,31 @@ a.add, a.delete {
                           [% END %]
                         </select>
                       </td>
+                      <td>
+                        <select name="search_field_staff_client">
+                          [% IF search_field.staff_client %]
+                            <option value="1" selected="selected">Yes</option>
+                            <option value="0">No</option>
+                          [% ELSE %]
+                            <option value="1">Yes</option>
+                            <option value="0" selected="selected">No</option>
+                          [% END %]
+                        </select>
+                      </td>
+                      <td>
+                        <select name="search_field_opac">
+                          [% IF search_field.opac %]
+                            <option value="1" selected="selected">Yes</option>
+                            <option value="0">No</option>
+                          [% ELSE %]
+                            <option value="1">Yes</option>
+                            <option value="0" selected="selected">No</option>
+                          [% END %]
+                        </select>
+                      </td>
+                      <td>
+                        <input type="text" size="3" name="search_field_boost" value="[% search_field.boost %]" />
+                      </td>
                     </tr>
                   [% END %]
                 </tbody>
@@ -179,6 +214,7 @@ a.add, a.delete {
                           <th>Sortable</th>
                           <th>Facetable</th>
                           <th>Suggestible</th>
+                          <th>Searchable</th>
                           <th>Mapping</th>
                           <th></th>
                         </tr>
@@ -233,6 +269,17 @@ a.add, a.delete {
                               </select>
                             </td>
                             <td>
+                              <select name="mapping_search">
+                                [% IF mapping.search %]
+                                  <option value="0">No</option>
+                                  <option value="1" selected="selected">Yes</option>
+                                [% ELSE %]
+                                  <option value="0" selected="selected">No</option>
+                                  <option value="1">Yes</option>
+                                [% END %]
+                              </select>
+                            </td>
+                            <td>
                                 <input name="mapping_marc_field" type="text" value="[% mapping.marc_field %]" />
                             </td>
                             <td><a class="btn btn-default btn-xs delete" style="cursor: pointer;"><i class="fa fa-trash"></i> Delete</a></td>
@@ -270,6 +317,17 @@ a.add, a.delete {
                           <td>
                             <select data-id="mapping_suggestible">
                               [% IF mapping.suggestible %]
+                                <option value="0">No</option>
+                                <option value="1" selected="selected">Yes</option>
+                              [% ELSE %]
+                                <option value="0" selected="selected">No</option>
+                                <option value="1">Yes</option>
+                              [% END %]
+                            </select>
+                          </td>
+                          <td>
+                            <select data-id="mapping_search">
+                              [% IF mapping.search %]
                                 <option value="0">No</option>
                                 <option value="1" selected="selected">Yes</option>
                               [% ELSE %]

--- a/opac/opac-search.pl
+++ b/opac/opac-search.pl
@@ -555,7 +555,7 @@ if (C4::Context->preference('OpacSuppression')) {
     \@sort_by,
     0,
     $lang,
-    { expanded_facet => $expanded_facet, suppress => $suppress }
+    { expanded_facet => $expanded_facet, suppress => $suppress, is_opac => 1 }
     );
 
 sub _input_cgi_parse {


### PR DESCRIPTION
Generate a list of fields for the query_string query fields parameter,
with possible boosts, instead of using "_all"-field. Also add "search"
flag in search_marc_to_field table so that certain mappings can be
excluded from searches. Add option to include/exclude fields in
query_string "fields" parameter depending on searching in OPAC or staff
client. Refactor code to remove all other dependencies on "_all"-field.

How to test:
1) No reindex is really required, but still, reindex authorities and
   biblios to verify that this still works.
2) Search biblios and try to verify that this works as expected.
3) Search authorities and try to verify that this works as expected.
4) Go to "Search engine configuration"
5) Change some "Boost", "Staff client", and "OPAC" settings and save.
6) Verify that those settings where saved accordingly.
7) Click the "Biblios" or "Authorities" tab and change one or more
   "Searchable" settings
8) Verfiy that those settings where saved accordingly.
9) Try to verify that these settings has taken effect by peforming
   some biblios and/or authorities searches.

Sponsorded-by: Gothenburg Univesity Library